### PR TITLE
Add token range implementation for pf2e

### DIFF
--- a/scripts/rangeExtSupport.js
+++ b/scripts/rangeExtSupport.js
@@ -158,6 +158,10 @@ class Dnd5eRange extends SystemRange {
 }
 
 class Pf2eRange extends SystemRange {
+  static getTokenRange(token) {
+    return [token.actor?.getReach?.({ action: 'attack' }) || 0];
+  }
+
   static getItemRange(item) {
     const ranges = [];
 


### PR DESCRIPTION
![image](https://github.com/Aedif/tactical-grid/assets/1286721/a0cdfcb2-4fcf-463b-9796-9a92d08f2d36)

That said, pf2e diagonal attacks have a special rule where 10 foot reach (and only 10 foot reach) can reach 2 squares diagonally. Would you have any insight on a good way to handle that rule that would play along with the module?