### PR TITLE
Fixed Token Action HUD item range highlight support.

### DIFF
--- a/scripts/rangeExtSupport.js
+++ b/scripts/rangeExtSupport.js
@@ -505,7 +505,7 @@ function _tokenActionHud() {
       token = null;
       return;
     }
-    token = hud.token;
+    token = hud.hudManager.token;
   });
 
   Hooks.on('tokenActionHudSystemActionHoverOn', (event, item) => {


### PR DESCRIPTION
fix (rangeExtSupport.js): Fixed issue where the token variable for Token Action HUD integration would use the pre 2.0 TAH variable thus setting it to undefined.

Token Action HUD 2.X is required now.