### PR TITLE
Shaded highlights

### DIFF
--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -76,6 +76,16 @@ export default class PF2e extends GenericSystem {
       else ranges.push(5);
     }
 
+    // Volley trait (e.g. "volley-30"): shade the penalty zone inside this distance
+    const volleyTrait = item.system?.traits?.value?.find((t) => t.startsWith('volley-'));
+    if (volleyTrait) {
+      const volleyRange = parseInt(volleyTrait.split('-')[1]);
+      if (Number.isFinite(volleyRange) && volleyRange > 0) {
+        // Shaded overlay inside volley penalty distance
+        ranges.push({ range: volleyRange, shaded: true, shadeColor: '#ff0000', shadeCoverage: 0.25});
+      }
+    }
+
     return ranges;
   }
 


### PR DESCRIPTION
Adds a new type of range highlight thats meant to go on top of already existing ones, to indicate additional range-based information.

Also includes an update to the PF2e item ranges to include a red-shaded range whenever a weapon has the `Volley` trait, as the volley trait in PF2e is a negative penalty.

# Images
Gridded
<img width="1176" height="887" alt="image" src="https://github.com/user-attachments/assets/6d97e885-ba87-4529-afb7-ddecd6432c37" />
Gridless
<img width="980" height="815" alt="image" src="https://github.com/user-attachments/assets/9dbf0a8b-924a-40f8-8d72-48f905889827" />

