### PR TITLE
PF2e: Fix PF2e HUD integration performance issue

### DIFF
--- a/scripts/modules/pf2eHud.js
+++ b/scripts/modules/pf2eHud.js
@@ -6,27 +6,28 @@
 import { RangeHighlightAPI } from '../rangeHighlighter.js';
 
 export function register() {
-  Hooks.once('renderPersistentShortcutsPF2eHUD', (hud, html, options, context) => {
-    $(html)
-      .on('mouseenter', '.item.shortcut', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
-      .on('mouseleave', '.item.shortcut', (event) =>
-        RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens())
-      );
+  Hooks.on('renderPersistentShortcutsPF2eHUD', (hud, html, options, context) => {
+    const shortcuts = html.querySelectorAll(".shortcut");
+    for (const shortcut of shortcuts) {
+      $(shortcut)
+          .on("mouseenter", null, (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
+          .on("mouseleave", null, (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
+    }
   });
 
-  Hooks.once('renderItemsSidebarPF2eHUD', (hud, html, options, context) => {
-    $(html)
-      .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
-      .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
-  });
-
-  Hooks.once('renderSpellsSidebarPF2eHUD', (hud, html, options, context) => {
+  Hooks.on('renderItemsSidebarPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
   });
 
-  Hooks.once('renderActionsSidebarPF2eHUD', (hud, html, options, context) => {
+  Hooks.on('renderSpellsSidebarPF2eHUD', (hud, html, options, context) => {
+    $(html)
+      .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
+      .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
+  });
+
+  Hooks.on('renderActionsSidebarPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));

--- a/scripts/modules/pf2eHud.js
+++ b/scripts/modules/pf2eHud.js
@@ -6,7 +6,7 @@
 import { RangeHighlightAPI } from '../rangeHighlighter.js';
 
 export function register() {
-  Hooks.on('renderPersistentShortcutsPF2eHUD', (hud, html, options, context) => {
+  Hooks.once('renderPersistentShortcutsPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item.shortcut', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item.shortcut', (event) =>
@@ -14,19 +14,19 @@ export function register() {
       );
   });
 
-  Hooks.on('renderItemsSidebarPF2eHUD', (hud, html, options, context) => {
+  Hooks.once('renderItemsSidebarPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
   });
 
-  Hooks.on('renderSpellsSidebarPF2eHUD', (hud, html, options, context) => {
+  Hooks.once('renderSpellsSidebarPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));
   });
 
-  Hooks.on('renderActionsSidebarPF2eHUD', (hud, html, options, context) => {
+  Hooks.once('renderActionsSidebarPF2eHUD', (hud, html, options, context) => {
     $(html)
       .on('mouseenter', '.item', (event) => highlightItemById(event.currentTarget.dataset.itemId, hud.actor))
       .on('mouseleave', '.item', (event) => RangeHighlightAPI.clearRangeHighlight(hud.actor.getActiveTokens()));


### PR DESCRIPTION
Noticed this while I was looking into https://github.com/Aedif/tactical-grid/pull/60, turns out the PF2e HUD re-uses the HTML elements, so adding a on-hover hook on each render causes the hooks to stack up, which was further compounding the performance issue with large ranges.

Before (notice console entry amounts):

[highlight-on-hover-before.webm](https://github.com/user-attachments/assets/739d63f7-ae4b-4194-b9f6-84d4857bda1f)

After:

[highlight-on-hover-fixed.webm](https://github.com/user-attachments/assets/975d5b5f-feb7-4c16-87fb-7d3ef4cd210b)
